### PR TITLE
Set default OAuth scope to READ

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
@@ -13,7 +13,7 @@ class RxAppMethods(client: MastodonClient) {
     fun createApp(
         clientName: String,
         redirectUris: String = "urn:ietf:wg:oauth:2.0:oob",
-        scope: Scope,
+        scope: Scope = Scope(Scope.Name.READ),
         website: String? = null
     ): Single<AppRegistration> {
         return Single.create {

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
@@ -17,7 +17,7 @@ class AppMethods(private val client: MastodonClient) {
      * @param clientName A name for your application
      * @param redirectUris Where the user should be redirected after authorization. Defaults to "urn:ietf:wg:oauth:2.0:oob",
      *  which will display the authorization code to the user instead of redirecting to a web page.
-     * @param scope Space separated list of scopes. Defaults to all scopes.
+     * @param scope Space separated list of scopes. Defaults to "read".
      * @param website A URL to the homepage of your app, defaults to null.
      * @see <a href="https://docs.joinmastodon.org/methods/apps/#create">Mastodon apps API methods #create</a>
      */
@@ -25,7 +25,7 @@ class AppMethods(private val client: MastodonClient) {
     fun createApp(
         clientName: String,
         redirectUris: String = "urn:ietf:wg:oauth:2.0:oob",
-        scope: Scope = Scope(Scope.Name.ALL),
+        scope: Scope = Scope(Scope.Name.READ),
         website: String? = null
     ): MastodonRequest<AppRegistration> {
         scope.validate()

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -18,13 +18,17 @@ class OAuthMethods(private val client: MastodonClient) {
      * or show the authorization code if urn:ietf:wg:oauth:2.0:oob was requested.
      * The authorization code can be used while requesting a token to obtain access to user-level methods.
      * @param clientId The client ID, obtained during app registration.
-     * @param scope List of requested OAuth scopes, separated by spaces. Must be a subset of scopes declared during app registration.
+     * @param scope List of requested OAuth scopes, separated by spaces. Must be a subset of scopes declared during app registration. Defaults to "read".
      * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
      *  which will display the authorization code to the user instead of redirecting to a web page.
      *  Must match one of the redirect_uris declared during app registration.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#authorize">Mastodon oauth API methods #authorize</a>
      */
-    fun getOAuthUrl(clientId: String, scope: Scope, redirectUri: String = "urn:ietf:wg:oauth:2.0:oob"): String {
+    fun getOAuthUrl(
+        clientId: String,
+        scope: Scope = Scope(Scope.Name.READ),
+        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob"
+    ): String {
         val endpoint = "oauth/authorize"
         val params = Parameters()
             .append("client_id", clientId)
@@ -43,6 +47,9 @@ class OAuthMethods(private val client: MastodonClient) {
      *  Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
      * @param grantType See Mastodon API documentation for details. Defaults to "authorization_code".
+     * @param scope List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters).
+     *  If "code" was provided, then this must be equal to the scope requested from the user. Otherwise, it must be
+     *  a subset of scopes declared during app registration. If not provided, defaults to "read".
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
     @JvmOverloads
@@ -51,7 +58,8 @@ class OAuthMethods(private val client: MastodonClient) {
         clientSecret: String,
         redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
         code: String,
-        grantType: String = "authorization_code"
+        grantType: String = "authorization_code",
+        scope: Scope = Scope(Scope.Name.READ)
     ): MastodonRequest<AccessToken> {
         return client.getMastodonRequest(
             endpoint = "oauth/token",
@@ -62,6 +70,7 @@ class OAuthMethods(private val client: MastodonClient) {
                 append("redirect_uri", redirectUri)
                 append("code", code)
                 append("grant_type", grantType)
+                append("scope", scope.toString())
             }
         )
     }


### PR DESCRIPTION
I have set the default Oauth scope to "read" where it was used. It would be nice, if we could test this somehow. Any ideas?