### PR TITLE
Add PKCE parameters to relevant OAuth methods

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
@@ -24,6 +24,9 @@ class RxOAuthMethods(client: MastodonClient) {
      * @param clientId The client ID, obtained during app registration.
      * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param scope List of requested OAuth scopes, separated by spaces. Must be a subset of scopes declared during app registration.
+     * @param state Arbitrary value to pass through to your server when the user authorizes or rejects the authorization request.
+     * @param codeChallenge The PKCE code challenge for the authorization request.
+     * @param codeChallengeMethod Must currently be `S256`, as this is the only code challenge method that is supported by Mastodon for PKCE.
      * @param forceLogin Forces the user to re-login, which is necessary for authorizing with multiple accounts from the same instance.
      * @param languageCode The ISO 639-1 two-letter language code to use while rendering the authorization form.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#authorize">Mastodon oauth API methods #authorize</a>
@@ -33,6 +36,9 @@ class RxOAuthMethods(client: MastodonClient) {
         clientId: String,
         redirectUri: String,
         scope: Scope? = null,
+        state: String? = null,
+        codeChallenge: String? = null,
+        codeChallengeMethod: String? = null,
         forceLogin: Boolean? = null,
         languageCode: String? = null
     ): Single<String> = Single.fromCallable {
@@ -40,6 +46,9 @@ class RxOAuthMethods(client: MastodonClient) {
             clientId,
             redirectUri,
             scope,
+            state,
+            codeChallenge,
+            codeChallengeMethod,
             forceLogin,
             languageCode
         )
@@ -51,6 +60,8 @@ class RxOAuthMethods(client: MastodonClient) {
      * @param clientSecret The client secret, obtained during app registration.
      * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
+     * @param codeVerifier Required if PKCE is used during the authorization request. This is the code verifier which was used
+     *  to create the `codeChallenge` using the `codeChallengeMethod` for the authorization request.
      * @param scope Requested OAuth scopes. Must be equal to the scope requested from the user while obtaining [code].
      *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
@@ -61,6 +72,7 @@ class RxOAuthMethods(client: MastodonClient) {
         clientSecret: String,
         redirectUri: String,
         code: String,
+        codeVerifier: String? = null,
         scope: Scope? = null
     ): Single<Token> = Single.fromCallable {
         oAuthMethods.getUserAccessTokenWithAuthorizationCodeGrant(
@@ -68,6 +80,7 @@ class RxOAuthMethods(client: MastodonClient) {
             clientSecret,
             redirectUri,
             code,
+            codeVerifier,
             scope
         ).execute()
     }

--- a/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
+++ b/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
@@ -17,7 +17,21 @@ public class OAuthGetAccessToken {
 
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         final Scope fullScope = new Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL);
-        final String url = client.oauth().getOAuthUrl(clientId, redirectUri, fullScope);
+        final String state = "example_state";
+
+        // example values generated via: https://example-app.com/pkce,
+        // should be generated according to: https://oauth.net/2/pkce/
+        final String codeVerifier = "4d165eefac426b3e61ef652b7b44d63aad113b0540ad25f5f10bc935";
+        final String codeChallenge = "LYcAAS1MRj9aDDd1cgPxku0YgFtJFH6_3_RGCWZGvOc";
+
+        final String url = client.oauth().getOAuthUrl(
+                clientId,
+                redirectUri,
+                fullScope,
+                state,
+                codeChallenge,
+                "S256" // currently no other method supported
+        );
         System.out.println("Open authorization page and copy code:");
         System.out.println(url);
         System.out.println("Paste code:");
@@ -30,6 +44,7 @@ public class OAuthGetAccessToken {
                 clientSecret,
                 redirectUri,
                 authCode,
+                codeVerifier,
                 fullScope);
 
         System.out.println("Access Token:");

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
@@ -28,7 +28,8 @@ object OAuthGetAccessToken {
             scope = fullScope,
             state = state,
             codeChallenge = codeChallenge,
-            codeChallengeMethod = "S256" // currently no other method supported
+            // currently no other method supported
+            codeChallengeMethod = "S256"
         )
         println("Open authorization page and copy code:")
         println(url)

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
@@ -15,18 +15,33 @@ object OAuthGetAccessToken {
         val redirectUri = args[3]
         val client = MastodonClient.Builder(instanceName).build()
         val fullScope = Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
-        val url = client.oauth.getOAuthUrl(clientId, redirectUri, fullScope)
+        val state = "example_state"
+
+        // example values generated via: https://example-app.com/pkce,
+        // should be generated according to: https://oauth.net/2/pkce/
+        val codeVerifier = "4d165eefac426b3e61ef652b7b44d63aad113b0540ad25f5f10bc935"
+        val codeChallenge = "LYcAAS1MRj9aDDd1cgPxku0YgFtJFH6_3_RGCWZGvOc"
+
+        val url = client.oauth.getOAuthUrl(
+            clientId = clientId,
+            redirectUri = redirectUri,
+            scope = fullScope,
+            state = state,
+            codeChallenge = codeChallenge,
+            codeChallengeMethod = "S256" // currently no other method supported
+        )
         println("Open authorization page and copy code:")
         println(url)
         println("Paste code:")
         var authCode: String
         Scanner(System.`in`).use { s -> authCode = s.nextLine() }
         val token = client.oauth.getUserAccessTokenWithAuthorizationCodeGrant(
-            clientId,
-            clientSecret,
-            redirectUri,
-            authCode,
-            fullScope
+            clientId = clientId,
+            clientSecret = clientSecret,
+            redirectUri = redirectUri,
+            code = authCode,
+            codeVerifier = codeVerifier,
+            scope = fullScope
         )
         println("Access Token:")
         println(token.execute().accessToken)


### PR DESCRIPTION
# Description

This adds parameters necessary for PKCE (Proof Key for Code Exchange) during OAuth authorization flow (see https://docs.joinmastodon.org/spec/oauth/#pkce). Specifically:

- adds parameters state, codeChallenge, codeChallengeMethod to getOAuthUrl()
- adds parameter codeVerifier to getUserAccessTokenWithAuthorizationCodeGrant()
- same for Rx methods
- modifies Kotlin+Java samples to make use of these parameters

Closes #531.

# Type of Change

- New feature

# Breaking Changes

- Changed parameter order in `getUserAccessTokenWithAuthorizationCodeGrant()`. Java users of the library will need to add a `null` parameter (as `codeVerifier`) before a non-null `scope` parameter if not using PKCE.

# How Has This Been Tested?

See below. Also ran modified samples against live Mastodon servers to confirm that PKCE parameters are used and correct.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods

Unit tests not possible, but samples do work.

# Optional checks

<!-- The items below are some more things to check before asking other people to review your code.
Please delete any entry that does not apply. If none apply, please also delete this whole section. -->

- [x] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
- [ ] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?

Documentation was not yet changed back from "fully supported".
