### PR TITLE
Clarify Status.filtered value being non-null

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
@@ -199,7 +199,8 @@ data class Status(
     val isPinned: Boolean = false,
 
     /**
-     * If the current token has an authorized user: The filter and keywords that matched this status. (optional)
+     * The filter and keywords that matched this status. If no filters matched, this list will be empty.
+     * May be null if the current token does not have an authorized user. (optional)
      */
     @SerialName("filtered")
     val filtered: List<FilterResult>? = null


### PR DESCRIPTION


# Description

Minor change to the kdoc of `Status.filtered` to clarify that this value, although nullable, will generally be non-null for authorized users, and will only be null if the request returning a `Status` was made without authorized user.

Closes #222.

# Type of Change

- Documentation

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

# Mandatory Checklist

Note: no code changes, only documentation.

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods
