### PR TITLE
Add attributionDomains to CredentialAccount

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/CredentialAccount.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/CredentialAccount.kt
@@ -181,6 +181,12 @@ data class CredentialAccount(
     val followingCount: Long = 0,
 
     /**
+     * Domains of websites allowed to credit the account.
+     */
+    @SerialName("attribution_domains")
+    val attributionDomains: List<String> = emptyList(),
+
+    /**
      * An extra attribute that contains source values
      * to be used with API methods that [AccountMethods.verifyCredentials] and [AccountMethods.updateCredentials].
      */

--- a/bigbone/src/test/assets/credential_account.json
+++ b/bigbone/src/test/assets/credential_account.json
@@ -14,6 +14,7 @@
   "avatar_static": "test",
   "header": "test",
   "header_static": "test",
+  "attribution_domains": ["example.com", "example.net"],
   "source": {
     "privacy": "public",
     "sensitive": false,

--- a/bigbone/src/test/kotlin/social/bigbone/api/entity/AccountsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/entity/AccountsTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import social.bigbone.JSON_SERIALIZER
 import social.bigbone.PrecisionDateTime
+import social.bigbone.api.entity.data.Visibility
 import social.bigbone.testtool.AssetsUtil
 
 class AccountsTest {
@@ -35,6 +36,22 @@ class AccountsTest {
         list[1].muteExpiresAt shouldBeInstanceOf PrecisionDateTime.InvalidPrecisionDateTime.Unavailable::class
         list[2].id shouldBeEqualTo "33333"
         list[2].muteExpiresAt shouldBeInstanceOf PrecisionDateTime.InvalidPrecisionDateTime.Unavailable::class
+    }
+
+    @Test
+    fun deserializeCredentialAccount() {
+        // given a JSON string containing valid CredentialAccount data
+        val json = AssetsUtil.readFromAssets("credential_account.json")
+
+        // when parsing as a CredentialAccount
+        val credentialAccount: CredentialAccount = JSON_SERIALIZER.decodeFromString(json)
+
+        // then retrieving CredentialAccount data should be possible
+        credentialAccount.attributionDomains.size shouldBeEqualTo 2
+        credentialAccount.attributionDomains.first() shouldBeEqualTo "example.com"
+        credentialAccount.source.note.startsWith("Lorem ipsum dolor sit amet") shouldBeEqualTo true
+        credentialAccount.source.privacy shouldBeEqualTo Visibility.PUBLIC
+        credentialAccount.source.fields.first().name shouldBeEqualTo "Website"
     }
 
     @Test


### PR DESCRIPTION
# Description

attribution_domains is a new attribute of CredentialAccounts since Mastodon 4.4.0.

Adds test to check for proper deserialization of `CredentialAccount` JSON data.

Closes #556.

# Type of Change

- New feature

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods