### PR TITLE
560 catch invalid error response

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
@@ -84,9 +84,13 @@ class MastodonRequest<T>(
                 throw BigBoneRequestException("Successful response could not be parsed", e)
             }
         } else {
-            val error = JSON_SERIALIZER.decodeFromString<Error>(response.body.string())
-            response.close()
-            throw BigBoneRequestException(response, error)
+            try {
+                val error = JSON_SERIALIZER.decodeFromString<Error>(response.body.string())
+                response.close()
+                throw BigBoneRequestException(response, error)
+            } catch (e: Exception) {
+                throw BigBoneRequestException("Request failed with unparseable error response", e)
+            }
         }
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
@@ -88,7 +88,7 @@ class MastodonRequest<T>(
                 val error = JSON_SERIALIZER.decodeFromString<Error>(response.body.string())
                 response.close()
                 throw BigBoneRequestException(response, error)
-            } catch (e: Exception) {
+            } catch (e: IllegalArgumentException) {
                 throw BigBoneRequestException("Request failed with unparseable error response", e)
             }
         }


### PR DESCRIPTION
# Description

Mastodon servers may return HTML error pages instead of a JSON response that can properly be parsed as Error, if the failure is not properly detected on their end. As a last resort, check for failing Error deserialization and throw an exception not based on that information instead.

Closes #560.

# Type of Change

- Bug fix

# How Has This Been Tested?

Ran failing code as described in #560 against Mastodon servers - error is properly caught with code change.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods