### PR TITLE
Reuse OkHttpClient built in client builder for instance request

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneClientInstantiationException.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneClientInstantiationException.kt
@@ -36,3 +36,9 @@ class ServerInfoUrlRetrievalException(response: Response, message: String? = nul
  * Exception thrown if we could not retrieve the instance version of a Mastodon server during [MastodonClient] instantiation.
  */
 class InstanceVersionRetrievalException(message: String, cause: Throwable? = null) : BigBoneClientInstantiationException(message, cause)
+
+/**
+ * Exception thrown if we could not retrieve the instance details of a Mastodon server during [MastodonClient] instantiation.
+ */
+class InstanceRetrievalException(message: String, cause: Throwable? = null) :
+    BigBoneClientInstantiationException(message, cause)

--- a/bigbone/src/test/kotlin/social/bigbone/MastodonClientTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/MastodonClientTest.kt
@@ -45,7 +45,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { true }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
             .withHttpsDisabled()
             .withPort(port)
@@ -72,7 +72,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { true }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
 
         invoking(clientBuilder::build)
@@ -99,7 +99,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { false }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
             .withHttpsDisabled()
             .withPort(port)
@@ -125,7 +125,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { false }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
         invoking(clientBuilder::build)
             .shouldThrow(InstanceVersionRetrievalException::class)
@@ -171,7 +171,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { true }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
 
         val mastodonClient = clientBuilder.build()
@@ -207,7 +207,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { true }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
 
         val mastodonClient = clientBuilder.build()
@@ -232,7 +232,7 @@ class MastodonClientTest {
                 every { isSuccessful } answers { false }
                 every { close() } returns Unit
             }
-            every { executeInstanceRequest() } answers { responseMock }
+            every { executeInstanceRequest(any()) } answers { responseMock }
         }
 
         val mastodonClient = clientBuilder.build()


### PR DESCRIPTION
# Description

This PR adds a reference of `Instance` to the `MastodonClient` _instance_ (🥁🐍). We previously already called the endpoint but manually got from the JSON only what we needed for the streaming API URL.

With this PR, the `Instance` retrieval is a necessary part of the `MastodonClient.Builder#build` call.

Closes #114 

# Type of Change

- Improvement of existing feature
- Addition of new property to `MastodonClient`

# Breaking Changes

- `MastodonClient.Builder#build` may now break in more ways than before. Previously, we gracefully failed if the endpoint to get an `Instance` didn’t work out for us to get a streaming API URL. Now, the whole `build` call fails with an `InstanceRetrievalException` that may wrap other exceptions that might have occurred during retrieval—JSON parsing exceptions, network call failures, …

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

# Mandatory Checklist

- [ ] I ran `gradle check` and there were no errors reported
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods

# Optional checks

<!-- The items below are some more things to check before asking other people to review your code.
Please delete any entry that does not apply. If none apply, please also delete this whole section. -->

- [ ] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
- [ ] In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
- [ ] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
