### PR TITLE
Limit PR builds to specific types; cancel on new push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Build
 
-on: [ push, pull_request ]
+on:
+  pull_request:
+    types: [ opened, reopened, ready_for_review, synchronize ]
+
+# Cancel previous runs for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-gradle-project:


### PR DESCRIPTION
# Description

I noticed that I got two emails for #562 despite the PR being in Draft state still:
1. Build failed before I had even created a PR because I had pushed the branch
2. Build failed when I had created a PR in Draft state

I propose to only run builds if a PR changes into an opened, reviewable state. So we would no longer run builds on every branch pushed, and only run builds on PRs that are not in Draft state.

Our builds don’t take long but why waste resources running builds multiple times and in states where the code changes are not even ready for review yet?

I’ve also added an auto-cancellation on new pushes to the same branch should an old build still be running. Again: Our builds don’t take too long so this is unlikely to happen often, but also should do no harm.

# Type of Change

- CI

# Breaking Changes

- None

# How Has This Been Tested?

I have used a similar setup in other projects and it worked fine.

# Mandatory Checklist

- [ ] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods