### PR TITLE
Add new user age restrictions

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
@@ -8,6 +8,7 @@ import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.CredentialAccount
 import social.bigbone.api.entity.FamiliarFollowers
 import social.bigbone.api.entity.FeaturedTag
+import social.bigbone.api.entity.Instance
 import social.bigbone.api.entity.MastodonList
 import social.bigbone.api.entity.Relationship
 import social.bigbone.api.entity.Status
@@ -35,7 +36,7 @@ class RxAccountMethods(client: MastodonClient) {
      * to the user in order to allow them to consent before setting this parameter to TRUE.
      * @param locale The language of the confirmation email that will be sent
      * @param reason If registrations require manual approval, this text will be reviewed by moderators.
-     * @param dateOfBirth If a minimum age is required, this date of birth must be provided and will be checked against.
+     * @param dateOfBirth If a minimum age is required (see [Instance.Registrations.minAge]), this date of birth must be provided and will be checked against.
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#create">Mastodon API documentation: methods/accounts/#create</a>
      */
     fun registerAccount(

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
@@ -15,6 +15,7 @@ import social.bigbone.api.entity.Token
 import social.bigbone.api.entity.data.Visibility
 import social.bigbone.api.method.AccountMethods
 import java.time.Duration
+import java.time.LocalDate
 
 /**
  * Reactive implementation of [AccountMethods].
@@ -34,6 +35,7 @@ class RxAccountMethods(client: MastodonClient) {
      * to the user in order to allow them to consent before setting this parameter to TRUE.
      * @param locale The language of the confirmation email that will be sent
      * @param reason If registrations require manual approval, this text will be reviewed by moderators.
+     * @param dateOfBirth If a minimum age is required, this date of birth must be provided and will be checked against.
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#create">Mastodon API documentation: methods/accounts/#create</a>
      */
     fun registerAccount(
@@ -42,9 +44,10 @@ class RxAccountMethods(client: MastodonClient) {
         password: String,
         agreement: Boolean,
         locale: String,
-        reason: String?
+        reason: String?,
+        dateOfBirth: LocalDate?
     ): Single<Token> = Single.fromCallable {
-        accountMethods.registerAccount(username, email, password, agreement, locale, reason).execute()
+        accountMethods.registerAccount(username, email, password, agreement, locale, reason, dateOfBirth).execute()
     }
 
     /**

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Instance.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Instance.kt
@@ -352,6 +352,13 @@ data class Instance(
         val approvalRequired: Boolean = false,
 
         /**
+         * The minimum user age in years, if set.
+         * @since Mastodon 4.4.0
+         */
+        @SerialName("min_age")
+        val minAge: Int? = null,
+
+        /**
          * A custom message to be shown when registrations are closed.
          * Nullable String (HTML) or null
          */

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
@@ -15,6 +15,7 @@ import social.bigbone.api.entity.Status
 import social.bigbone.api.entity.Token
 import social.bigbone.api.entity.data.Visibility
 import java.time.Duration
+import java.time.LocalDate
 
 /**
  * Allows access to API methods with endpoints having an "api/vX/accounts" prefix.
@@ -33,6 +34,7 @@ class AccountMethods(private val client: MastodonClient) {
      * to the user in order to allow them to consent before setting this parameter to TRUE.
      * @param locale The language of the confirmation email that will be sent
      * @param reason If registrations require manual approval, this text will be reviewed by moderators.
+     * @param dateOfBirth If a minimum age is required, this date of birth must be provided and will be checked against.
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#create">Mastodon API documentation: methods/accounts/#create</a>
      */
     fun registerAccount(
@@ -41,7 +43,8 @@ class AccountMethods(private val client: MastodonClient) {
         password: String,
         agreement: Boolean,
         locale: String,
-        reason: String?
+        reason: String?,
+        dateOfBirth: LocalDate?
     ): MastodonRequest<Token> {
         return client.getMastodonRequest(
             endpoint = endpoint,
@@ -53,6 +56,7 @@ class AccountMethods(private val client: MastodonClient) {
                 append("agreement", agreement)
                 append("locale", locale)
                 reason?.let { append("reason", it) }
+                dateOfBirth?.let { append("date_of_birth", it.toString()) }
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
@@ -9,6 +9,7 @@ import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.CredentialAccount
 import social.bigbone.api.entity.FamiliarFollowers
 import social.bigbone.api.entity.FeaturedTag
+import social.bigbone.api.entity.Instance
 import social.bigbone.api.entity.MastodonList
 import social.bigbone.api.entity.Relationship
 import social.bigbone.api.entity.Status
@@ -34,7 +35,7 @@ class AccountMethods(private val client: MastodonClient) {
      * to the user in order to allow them to consent before setting this parameter to TRUE.
      * @param locale The language of the confirmation email that will be sent
      * @param reason If registrations require manual approval, this text will be reviewed by moderators.
-     * @param dateOfBirth If a minimum age is required, this date of birth must be provided and will be checked against.
+     * @param dateOfBirth If a minimum age is required (see [Instance.Registrations.minAge]), this date of birth must be provided and will be checked against.
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#create">Mastodon API documentation: methods/accounts/#create</a>
      */
     fun registerAccount(

--- a/bigbone/src/test/assets/instance_extended.json
+++ b/bigbone/src/test/assets/instance_extended.json
@@ -81,6 +81,7 @@
   "registrations": {
     "enabled": false,
     "approval_required": false,
+    "min_age": 42,
     "message": null
   },
   "contact": {

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AccountMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AccountMethodsTest.kt
@@ -19,6 +19,7 @@ import social.bigbone.testtool.MockClient
 import social.bigbone.testtool.TestUtil.urlEncode
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 
 class AccountMethodsTest {
 
@@ -33,7 +34,8 @@ class AccountMethodsTest {
             password = "password",
             agreement = true,
             locale = "DE",
-            reason = "Please let me in!"
+            reason = "Please let me in!",
+            dateOfBirth = LocalDate.of(1990, 1, 1)
         ).execute()
 
         with(token) {
@@ -42,6 +44,39 @@ class AccountMethodsTest {
             scope shouldBeEqualTo "read write follow push"
             createdAt shouldBeEqualTo 1_573_979_017L
         }
+        val parametersCapturingSlot = slot<Parameters>()
+        verify {
+            client.post(
+                path = accountMethods.endpoint,
+                body = capture(parametersCapturingSlot)
+            )
+        }
+        with(parametersCapturingSlot.captured) {
+            toQuery() shouldBeEqualTo "username=username" +
+                "&email=email" +
+                "&password=password" +
+                "&agreement=true" +
+                "&locale=DE" +
+                "&reason=Please+let+me+in%21" +
+                "&date_of_birth=1990-01-01"
+        }
+    }
+
+    @Test
+    fun `When registering account with no date of birth, then call endpoint without date_of_birth`() {
+        val client = MockClient.mock("accounts_register_success.json")
+        val accountMethods = AccountMethods(client)
+
+        val token = accountMethods.registerAccount(
+            username = "username",
+            email = "email",
+            password = "password",
+            agreement = true,
+            locale = "DE",
+            reason = "Please let me in!",
+            dateOfBirth = null
+        ).execute()
+
         val parametersCapturingSlot = slot<Parameters>()
         verify {
             client.post(
@@ -75,7 +110,8 @@ class AccountMethodsTest {
                 password = "",
                 agreement = false,
                 locale = "DE",
-                reason = "Please let me in!"
+                reason = "Please let me in!",
+                dateOfBirth = LocalDate.of(1990, 1, 1)
             ).execute()
         }
             .shouldThrow(BigBoneRequestException::class)

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/InstanceMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/InstanceMethodsTest.kt
@@ -96,6 +96,7 @@ class InstanceMethodsTest {
         with(instance.registrations) {
             enabled shouldBeEqualTo false
             approvalRequired shouldBeEqualTo false
+            minAge shouldBeEqualTo 42
             message.shouldBeNull()
         }
 


### PR DESCRIPTION
# Description

This PR adds the new `Instance.configuration.registrations.min_age` attribute as an optional `Int` value as well as the `date_of_birth` parameter for the registration method.

#572 

# Type of Change

- Improvement of existing features

# Breaking Changes

<!-- A breaking change is a change to supported functionality between released versions of a library that would require 
a customer to do work in order to upgrade to the newer version. If your change includes one or more breaking changes, 
please list/document them here, otherwise set "None". This information will be published in our release notes. -->

- `AccountMethods#registerAccount` and `RxAccountMethods#registerAccount` now have a new `dateOfBirth` parameter of type `LocalDate?` as the last parameter. Set `null` here if you’re not propagating the date of birth from your UI.

# How Has This Been Tested?

I have only run `gradle check` but did not attempt to register a new account with the new parameter in place.

> [!WARNING]
> I’m not sure how a Mastodon server that doesn’t know the new parameter would react if we were to send it!

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods

# Optional checks

- [x] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
