### PR TITLE
Clarify use of resolve parameter in search

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
@@ -39,7 +39,8 @@ class SearchMethods(private val client: MastodonClient) {
      * @see <a href="https://github.com/mastodon/documentation/issues/1336">Mastodon issue: incomplete documentation of offset/type parameters</a>
      * @param query string to search for
      * @param type to specify if you are looking for a specific typology
-     * @param resolve whether to resolve non-local accounts
+     * @param resolve whether to resolve non-local accounts; also, if the search term is an HTTPS URL,
+     *  whether to resolve and if possible return the corresponding status
      * @param following whether to include accounts that the user is following
      * @param excludeUnreviewed whether to look for trending tags
      * @param accountId to only return statuses authored by the user account


### PR DESCRIPTION
# Description

Mastodon documentation has been updated to clarify that the `resolve` parameter is also used to determine whether HTTPS URL search query should result in the matching status to be returned. See https://github.com/mastodon/documentation/issues/1644

# Type of Change

- Documentation

# Breaking Changes

None

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods
