### PR TITLE
Allow disabling compatibility checks

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FilterMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FilterMethods.kt
@@ -61,7 +61,7 @@ class FilterMethods(private val client: MastodonClient) {
         filterAction: Filter.FilterAction = Filter.FilterAction.WARN
     ): MastodonRequest<Filter> {
         // see: https://github.com/mastodon/mastodon/pull/34256
-        if (filterAction == Filter.FilterAction.BLUR && client.getInstance().apiVersions.mastodon < 5) {
+        if (client.performCompatibilityChecks && filterAction == Filter.FilterAction.BLUR && client.getInstance().apiVersions.mastodon < 5) {
             throw BigBoneRequestException("FilterAction.BLUR not available on Mastodon instance with API version < 5")
         }
 

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -106,6 +106,7 @@ object MockClient {
         every { clientMock.put(any<String>(), any<Parameters>()) } returns response
         every { clientMock.putRequestBody(any<String>(), any<RequestBody>()) } returns response
         every { clientMock.performAction(any<String>(), any<MastodonClient.Method>(), any<Parameters>()) } returns Unit
+        every { clientMock.performCompatibilityChecks } returns true
         return clientMock
     }
 
@@ -137,6 +138,7 @@ object MockClient {
                 any<Parameters>()
             )
         } throws BigBoneRequestException("mock")
+        every { clientMock.performCompatibilityChecks } returns true
         return clientMock
     }
 


### PR DESCRIPTION
# Description

#577 requests an option to disable checks for the software and version of servers the BigBone library connects to. This PR does this by offering new functionality in `MastodonClient.Builder`:

Checks disabled by calling `disableCompatibilityChecks()` include the initial check for the server software reporting as Mastodon while building the client, as well as subsequent checks for the exact API version in use. This allows the resulting MastodonClient to be used with other server software offering a Mastodon-compatible API, at the cost of having to check for invalid requests yourself. Endpoints and individual attributes not defined in the official Mastodon API are not supported.

Following this change, all checks of `client.getInstance().apiVersions.mastodon` that we might want to add in the future would need to be wrapped in `if (client.performCompatibilityChecks) { ... }`. `FilterMethods.createFilter(...)` is an example of how this might look.

No breaking change, behaviour when _not_ calling `disableCompatibilityChecks()` when building a client should stay the same.

Closes #577.

# Type of Change

- New feature

# How Has This Been Tested?

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods
